### PR TITLE
Binding with current user, and cache of users in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Troubleshooting
 
 About the user cache
 --------------------
-When a successful login is made against an LDAP server the plugin will cache the username and encrypted password. Currently this is done by saving them in an array in YOURLS options table. This has some advantages:
+When a successful login is made against an LDAP server the plugin will cache the username and encrypted password. Currently this is done by saving them in an array in the YOURLS options table. This has some advantages:
 
   * It reduces requests to the LDAP server
   * It means that users can still log in even if the LDAP server is unreachable
   * It means that the YOURLS API can be used by LDAP users
 
 Unfortunately, the cache will not scale well. This is because it integrates tightly with YOURLS's internal auth mechanism, and that does not scale. If you have a few tens of LDAP users likely to use your YOURLS installation it should be fine. Much more than that and you may see performance issues. If so, you should probably disable the cache. This will mean
-that your LDAP users will not be able to use the API. At least not unless they are listed in users/config.php, which suffers from the same scaling problems. 
+that your LDAP users will not be able to use the API. At least not unless they are also listed in users/config.php, which suffers from the same scaling problems. 
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -12,37 +12,56 @@ Installation
 
 Usage
 -----
-When yourls-cas-plugin is enabled and user was not successfuly authenticated using data specified in yourls_user_passwords, an LDAP authentication attempt will be made. If LDAP authentication is successful, then you will immediately go to the admin interface.
+When yourls-ldap-plugin is enabled and user was not successfuly authenticated using data specified in yourls_user_passwords, an LDAP authentication attempt will be made. If LDAP authentication is successful, then you will immediately go to the admin interface.
 
-You can also set a privileged account to search the LDAP directory with. This is useful for directories that don't allow anonymous binding.
+You can also set a privileged account to search the LDAP directory with. This is useful for directories that don't allow anonymous binding. If you define a suitable template, the current user will be used binding. This is useful for Active Directory / Samba. 
 
 Setting the groups settings will check the user is a member of that group before logging them in and storing their credentials. This check is only performed the first time they auth or when their password changes.
+
+yourls-ldap-plugin by default will now implement a simple cache of LDAP users. As well as reducing requests to the LDAP server this has the effect of allowing YOURLS API to work with LDAP users.
 
 Configuration
 -------------
 
-  * define( 'LDAPAUTH_HOST', 'ldaps://ldap.domain.com' ) // LDAP host name, IP or URL. You can use ldaps://host for LDAP with TLS
-  * define( 'LDAPAUTH_PORT', '636' ) // LDAP server port - often 389 or 636 for TLS (LDAPS)
-  * define( 'LDAPAUTH_BASE', 'dc=domain,dc=com' ) // Base DN (location of users)
-  * define( 'LDAPAUTH_USERNAME_FIELD', 'uid') // (optional) LDAP field name in which username is store
+  * define( 'LDAPAUTH_HOST', 'ldaps://ldap.domain.com' ); // LDAP host name, IP or URL. You can use ldaps://host for LDAP with TLS
+  * define( 'LDAPAUTH_PORT', '636' ); // LDAP server port - often 389 or 636 for TLS (LDAPS)
+  * define( 'LDAPAUTH_BASE', 'dc=domain,dc=com' ); // Base DN (location of users)
+  * define( 'LDAPAUTH_USERNAME_FIELD', 'uid'); // (optional) LDAP field name in which username is store
 
 To use a privileged account for the user search:
-  * define( 'LDAPAUTH_SEARCH_USER', 'cn=your-user,dc=domain,dc=com' ) // (optional) Privileged user to search with
-  * define( 'LDAPAUTH_SEARCH_PASS', 'the-pass') // (optional) (only if LDAPAUTH_SEARCH_USER set) Privileged user pass
+  * define( 'LDAPAUTH_SEARCH_USER', 'cn=your-user,dc=domain,dc=com' ); // (optional) Privileged user to search with
+  * define( 'LDAPAUTH_SEARCH_PASS', 'the-pass'); // (optional) (only if LDAPAUTH_SEARCH_USER set) Privileged user pass
+
+To define a template to bind using the current user for the search: Use %s as the place holder for the current user name
+  * define( 'LDAPAUTH_BIND_WITH_USER_TEMPLATE', '%s@myad.domain' ); // (optional) Use %s as the place holder for the current user name
 
 To check group membership before authenticating:
-  * define( 'LDAPAUTH_GROUP_ATTR', 'memberof' ) // (optional) LDAP groups attr
-  * define( 'LDAPAUTH_GROUP_REQ', 'the-group;another-admin-group') // (only if LDAPAUTH_GROUP_REQ set) Group/s user must be in. Allows multiple, semicolon delimited
+  * define( 'LDAPAUTH_GROUP_ATTR', 'memberof' ); // (optional) LDAP groups attr
+  * define( 'LDAPAUTH_GROUP_REQ', 'the-group;another-admin-group'); // (only if LDAPAUTH_GROUP_REQ set) Group/s user must be in. Allows multiple, semicolon delimited
+
+To define the type of user cache used:
+  * define( 'LDAPAUTH_USERCACHE_TYPE', 0); // (optional) Defaults to 1, which caches users in the options table. 0 turns off cacheing. Other values are currently undefined, but may be one day
 
 To automatically add LDAP users to config.php:
-  * define( 'LDAPAUTH_ADD_NEW', true ) // (optional) Add LDAP users to config.php
-NOTE: This will require config.php to be writable by your webserver user
+  * define( 'LDAPAUTH_ADD_NEW', true ); // (optional) Add LDAP users to config.php
+NOTE: This will require config.php to be writable by your webserver user. This function is now largely unneeded because the database based cache offers similar benefits without the need to make config.php writeable. It is retained for backwards compatability
  
 Troubleshooting
 ---------------
   * Check PHP error log usually at `/var/log/php.log`
   * Check your webserver logs
   * You can try modifying plugin code to print some more debug info
+
+About the user cache
+--------------------
+When a successful login is made against an LDAP server the plugin will cache the username and encrypted password. Currently this is done by saving them in an array in YOURLS options table. This has some advantages:
+
+  * It reduces requests to the LDAP server
+  * It means that users can still log in even if the LDAP server is unreachable
+  * It means that the YOURLS API can be used by LDAP users
+
+Unfortunately, the cache will not scale well. This is because it integrates tightly with YOURLS's internal auth mechanism, and that does not scale. If you have a few tens of LDAP users likely to use your YOURLS installation it should be fine. Much more than that and you may see performance issues. If so, you should probably disable the cache. This will mean
+that your LDAP users will not be able to use the API. At least not unless they are listed in users/config.php, which suffers from the same scaling problems. 
 
 License
 -------

--- a/plugin.php
+++ b/plugin.php
@@ -148,11 +148,8 @@ function ldapauth_is_valid_user( $value ) {
 				if (!$in_group) die('Not in admin group');
 			}
 			
-			$username = $searchResult[0][LDAPAUTH_USERNAME_FIELD][0];
-			if (empty($username)) { 
-				// try with it lower cased
-				$username = $searchResult[0][strtolower(LDAPAUTH_USERNAME_FIELD)][0];
-			}
+			// attribute index returned by ldap_get_entries is lowercased (http://php.net/manual/en/function.ldap-get-entries.php)
+			$username = $searchResult[0][strtolower(LDAPAUTH_USERNAME_FIELD)][0];
 			yourls_set_user($username);
 			
 			if (LDAPAUTH_ADD_NEW && !array_key_exists($username, $yourls_user_passwords)) {


### PR DESCRIPTION
This pull request adds a couple of features:

The option to have the current user used to bind for the search. This is useful for things like Active Directory, which won't allow anonymous binds, if you don't wish to store credentials for a privileged user in `user/config.php`. To use this, a template must be defined in `LDAPAUTH_BIND_WITH_USER_TEMPLATE`. This is a simple sprintf statement with %s being substituted for the current login username. The result should be some RDN that can be used for the bind. For Active Directory something like eg `%s@myactivedirectory.domain.com` or `MYNTDOMAIN\%s`

Also added is a cache of successful user logins. This has similar benefits to writing users to `user/config.php`, but without the need for write access to that file. The cache stores an array of successfully logged in users in the options table. A big advantage of this is that it allows API calls to be made by LDAP users. It also prevents the "Stealing cookies" error (issue #8).

Additionally, if the user chooses to disable the cache, a dummy entry is made in $yourls_user_passwords to work around the "Stealing cookies" problem.