### PR TITLE
Added Active Directory LDAP hostname lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ To define the type of user cache used:
 
 To automatically add LDAP users to config.php:
   * define( 'LDAPAUTH_ADD_NEW', true ); // (optional) Add LDAP users to config.php
+  
+To use Active Directory Sites and Services DNS entry for LDAP server name lookup
+  * define( 'LDAPAUTH_DNS_SITES_AND_SERVICES', '_ldap._tcp.corporate._sites.yourdomain.com' ); // If using Active Directory, with multiple Domain Controllers, the safe way to use DNS to look up your active LDAP server names.  If set, it will be used to override the hostname portion of LDAPAUTH_HOST.
+  * define( 'LDAPAUTH_HOST', 'ldap://'); // LDAP protocol without hostname. You can use 'ldaps://' for LDAP with TLS.
+
 NOTE: This will require config.php to be writable by your webserver user. This function is now largely unneeded because the database based cache offers similar benefits without the need to make config.php writeable. It is retained for backwards compatability
  
 Troubleshooting


### PR DESCRIPTION
If you are using Active Directory, you likely have multiple LDAP servers.  Which servers your Windows clients use is controlled by a DNS entry for sites and services.  This DNS entry looks like _ldap._tcp.corporate._sites.yourdomain.com .  This code change allows for the LDAP host name to be looked up automatically based on the DNS entry.  This way if your Active Directory architecture changes (different Domain Controllers / LDAP servers ), you won't need to update this plugin's configuration.  This is only enabled if you set the new LDAPAUTH_DNS_SITES_AND_SERVICES configuration value.  Please see documentation in the README.md.