### PR TITLE
Add ldaps:// URI support and strict TLS certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,70 @@
+# YOURLS LDAPS / StartTLS plugin
+
+This is a fork of [mattv8/yourls-ldap-plugin](https://github.com/mattv8/yourls-ldap-plugin) with two extra features:
+
+1. **Full `ldaps://` URI support** via a new `LDAPAUTH_LDAP_URI` constant.
+2. **Strict TLS certificate verification** (`LDAP_OPT_X_TLS_DEMAND`) for StartTLS, instead of `NEVER`.
+
+The original plugin only supports `ldap_connect(host, port)` and, if `LDAPAUTH_START_TLS` is set, it used `LDAP_OPT_X_TLS_NEVER`. This fork lets you point YOURLS at a real `ldaps://` endpoint and still verifies the server certificate.
+
+## Changes vs. upstream
+
+```diff
+--- a/plugin.php
++++ b/plugin.php
+@@ -126,7 +126,10 @@ function ldapauth_get_ldap_connection()
+ 	} else {
+-		return ldap_connect(LDAPAUTH_HOST, LDAPAUTH_PORT);
++		if (defined("LDAPAUTH_LDAP_URI") && LDAPAUTH_LDAP_URI) {
++			return ldap_connect(LDAPAUTH_LDAP_URI);
++		}
++		return ldap_connect(LDAPAUTH_HOST, LDAPAUTH_PORT);
+ 	}
+@@
+ 		ldap_set_option($ldapConnection, LDAP_OPT_PROTOCOL_VERSION, 3);
++		ldap_set_option($ldapConnection, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_DEMAND);
+ 		if (defined("LDAPAUTH_START_TLS") && LDAPAUTH_START_TLS) {
+ 			@ldap_start_tls($ldapConnection);
+ 		}
+```
+
+## New/used constants
+
+- `LDAPAUTH_LDAP_URI` — e.g. `ldaps://ad.example.com:636`. If set and non-empty, it overrides `LDAPAUTH_HOST` / `LDAPAUTH_PORT`.
+- `LDAPAUTH_HOST` / `LDAPAUTH_PORT` — still used as fallback if `LDAPAUTH_LDAP_URI` is not defined.
+- `LDAPAUTH_START_TLS` — set to `true` to use StartTLS on `ldap://` port 389. Not used when on `ldaps://`.
+
+## How to install
+
+1. Download `plugin.php`.
+2. Place it in `user/plugins/ldap/` of your YOURLS install.
+3. Add the constants to `user/config.php`. Example:
+
+```php
+define( 'LDAPAUTH_HOST', 'ad.example.com' );
+define( 'LDAPAUTH_PORT', 389 );
+define( 'LDAPAUTH_LDAP_URI', 'ldaps://ad.example.com:636' );
+define( 'LDAPAUTH_BASE', 'DC=example,DC=com' );
+define( 'LDAPAUTH_USERNAME_FIELD', 'sAMAccountName' );
+define( 'LDAPAUTH_SEARCH_USER', 'CN=ldap,DC=example,DC=com' );
+define( 'LDAPAUTH_SEARCH_PASS', 'your-secure-password' );
+define( 'LDAPAUTH_START_TLS', false );
+define( 'LDAPAUTH_ALL_USERS_ADMIN', true );
+define( 'LDAPAUTH_USERCACHE_TYPE', 1 );
+```
+
+## Notes
+
+- For `ldaps://`, set `LDAPAUTH_LDAP_URI` and `LDAPAUTH_START_TLS` to `false`.
+- For StartTLS on 389, leave `LDAPAUTH_LDAP_URI` unset and set `LDAPAUTH_START_TLS` to `true`.
+- The CA certificate must be in the system's trust store (e.g. `/etc/ssl/certs`, updated with `update-ca-certificates`, or `SSL_CERT_FILE` / `CURL_CA_BUNDLE` for libldap).
+
+## License
+
+This plugin is based on `mattv8/yourls-ldap-plugin`, which is licensed under the GNU General Public License v3. The original license and copyright remain with the original authors.
+
+
+
 yourls-ldap-plugin
 ==================
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# YOURLS LDAPS / StartTLS plugin
+# YOURLS LDAP / LDAPS Auth Plugin
 
-This is a fork of [mattv8/yourls-ldap-plugin](https://github.com/mattv8/yourls-ldap-plugin) with two extra features:
+This is a fork of [mattv8/yourls-ldap-plugin](https://github.com/mattv8/yourls-ldap-plugin) that adds two features for production LDAPS deployments:
 
 1. **Full `ldaps://` URI support** via a new `LDAPAUTH_LDAP_URI` constant.
-2. **Strict TLS certificate verification** (`LDAP_OPT_X_TLS_DEMAND`) for StartTLS, instead of `NEVER`.
+2. **Strict TLS certificate verification** (`LDAP_OPT_X_TLS_DEMAND`) for StartTLS, instead of `LDAP_OPT_X_TLS_NEVER`.
 
 The original plugin only supports `ldap_connect(host, port)` and, if `LDAPAUTH_START_TLS` is set, it used `LDAP_OPT_X_TLS_NEVER`. This fork lets you point YOURLS at a real `ldaps://` endpoint and still verifies the server certificate.
 
@@ -28,21 +28,88 @@ The original plugin only supports `ldap_connect(host, port)` and, if `LDAPAUTH_S
  		}
 ```
 
-## New/used constants
-
-- `LDAPAUTH_LDAP_URI` — e.g. `ldaps://ad.example.com:636`. If set and non-empty, it overrides `LDAPAUTH_HOST` / `LDAPAUTH_PORT`.
-- `LDAPAUTH_HOST` / `LDAPAUTH_PORT` — still used as fallback if `LDAPAUTH_LDAP_URI` is not defined.
-- `LDAPAUTH_START_TLS` — set to `true` to use StartTLS on `ldap://` port 389. Not used when on `ldaps://`.
-
-## How to install
+## Installation
 
 1. Download `plugin.php`.
-2. Place it in `user/plugins/ldap/` of your YOURLS install.
-3. Add the constants to `user/config.php`. Example:
+2. Copy the plugin folder into your `user/plugins/` folder for YOURLS.
+3. Set up the parameters for the plugin in `user/config.php` (see below).
+4. Activate the plugin with the plugin manager in the admin interface.
+
+## Usage
+
+When the plugin is enabled and a user was not successfully authenticated using data specified in `$yourls_user_passwords`, an LDAP authentication attempt will be made. If LDAP authentication is successful, then you will immediately go to the admin interface.
+
+You can also set a privileged account to search the LDAP directory with. This is useful for directories that don't allow anonymous binding. If you define a suitable template, the current user will be used for binding. This is useful for Active Directory / Samba.
+
+Setting the groups settings will check if the user is a member of that group before logging them in and storing their credentials. This check is only performed the first time they authenticate or when their password changes.
+
+By default, the plugin implements a simple cache of LDAP users. As well as reducing requests to the LDAP server, this has the effect of allowing the YOURLS API to work with LDAP users.
+
+## Configuration
+
+These are the available constants for `user/config.php`.
+
+### Connection settings
+
+- `define( 'LDAPAUTH_LDAP_URI', 'ldaps://ldap.domain.com:636' );` (new) **Full LDAP URI**, including protocol and port. Use this for `ldaps://`. If set, it overrides `LDAPAUTH_HOST` / `LDAPAUTH_PORT`.
+- `define( 'LDAPAUTH_HOST', 'ldap.domain.com' );` (fallback) LDAP host name or IP. Used only if `LDAPAUTH_LDAP_URI` is not defined.
+- `define( 'LDAPAUTH_PORT', 636 );` (fallback) LDAP server port — often `389` for `ldap://` or `636` for `ldaps://`.
+- `define( 'LDAPAUTH_BASE', 'dc=domain,dc=com' );` Base DN (location of users).
+- `define( 'LDAPAUTH_USERNAME_FIELD', 'uid');` (optional) LDAP field name in which the username is stored.
+- `define( 'LDAPAUTH_START_TLS', false );` (optional) Set to `true` to use StartTLS on `ldap://` port 389. Not used when `LDAPAUTH_LDAP_URI` is an `ldaps://` URI.
+
+### TLS / certificate notes
+
+- For `ldaps://`, set `LDAPAUTH_LDAP_URI` to the full URI and keep `LDAPAUTH_START_TLS` as `false`.
+- For StartTLS on port 389, leave `LDAPAUTH_LDAP_URI` unset and set `LDAPAUTH_START_TLS` to `true`.
+- The CA certificate must be in the system's trust store (e.g. `/etc/ssl/certs`, updated with `update-ca-certificates`, or `SSL_CERT_FILE` / `CURL_CA_BUNDLE` for libldap). This plugin now uses `LDAP_OPT_X_TLS_DEMAND`, so a valid certificate is required.
+
+### Privileged account for the user search
+
+- `define( 'LDAPAUTH_SEARCH_USER', 'cn=your-user,dc=domain,dc=com' );` (optional) Privileged user to search with.
+- `define( 'LDAPAUTH_SEARCH_PASS', 'the-pass');` (optional) Privileged user password (only if `LDAPAUTH_SEARCH_USER` is set).
+
+### Template to bind using the current user
+
+- `define( 'LDAPAUTH_BIND_WITH_USER_TEMPLATE', '%s@myad.domain' );` (optional) Use `%s` as the placeholder for the current username.
+
+### Custom LDAP search filter
+
+- `define( 'LDAPAUTH_SEARCH_FILTER', '(&(samaccountname=%s)(memberof=YOURLS-ADMINS,OU=Groups,DC=example,DC=com))' );` Use `%s` as the placeholder for the current username. If this option is not set, the filter is based only on `LDAPAUTH_USERNAME_FIELD`.
+
+For AD nested groups, the `LDAP_MATCHING_RULE_IN_CHAIN` OID (1.2.840.113556.1.4.1941) can be used:
+```php
+define( 'LDAPAUTH_SEARCH_FILTER', '(&(samaccountname=%s)(memberof:1.2.840.113556.1.4.1941:=YOURLS-ADMINS,OU=Groups,DC=example,DC=com))' );
+```
+
+### Group membership check
+
+**Attribute based** (default):
+- `define( 'LDAPAUTH_GROUP_MODE', 'attribute');`
+- `define( 'LDAPAUTH_GROUP_ATTR', 'memberof' );` (optional)
+- `define( 'LDAPAUTH_GROUP_REQ', 'the-group;another-admin-group');` Group/s the user must be in. Allows multiple, semicolon-delimited.
+
+**Group based**:
+- `define( 'LDAPAUTH_GROUP_MODE', 'group');`
+- `define( 'LDAPAUTH_GROUP_BASE', 'ou=groups,dc=example,dc=org' );`
+- `define( 'LDAPAUTH_GROUP_ATTR', 'cn' );`
+- `define( 'LDAPAUTH_GROUP_MEMBER', 'member' );`
+- `define( 'LDAPAUTH_GROUP_MEMBER_TYPE', 'dn' );` either `dn` (default) or `uid`
+- `define( 'LDAPAUTH_GROUP_REQ', 'yourlsadmin');` Group/s user must be in. Semicolon-delimited.
+
+Group-based authorization **requires** `LDAPAUTH_SEARCH_USER` and `LDAPAUTH_SEARCH_PASS`.
+
+### Other settings
+
+- `define( 'LDAPAUTH_GROUP_SCOP', 'sub' );` Scope of group search: `sub` (default, checks all the subtree) or `base` (only the exact group).
+- `define( 'LDAPAUTH_USERCACHE_TYPE', 1);` `1` caches users in the options table (default). `0` turns off caching.
+- `define( 'LDAPAUTH_ADD_NEW', true );` (optional) Add LDAP users to `config.php`.
+- `define( 'LDAPAUTH_DNS_SITES_AND_SERVICES', '_ldap._tcp.corporate._sites.yourdomain.com' );` If using AD with multiple DCs, this DNS SRV lookup is used to find active LDAP server names. If set, it overrides the hostname portion of `LDAPAUTH_HOST`.
+- `define( 'LDAPAUTH_LDAP_OPT_REFERRALS', 0 );` (optional) Defaults to `1`. Set to `0` to prevent following AD referrals, which can sometimes cause `ldap_search` to hang.
+
+## Example: full `ldaps://` configuration
 
 ```php
-define( 'LDAPAUTH_HOST', 'ad.example.com' );
-define( 'LDAPAUTH_PORT', 389 );
 define( 'LDAPAUTH_LDAP_URI', 'ldaps://ad.example.com:636' );
 define( 'LDAPAUTH_BASE', 'DC=example,DC=com' );
 define( 'LDAPAUTH_USERNAME_FIELD', 'sAMAccountName' );
@@ -53,129 +120,44 @@ define( 'LDAPAUTH_ALL_USERS_ADMIN', true );
 define( 'LDAPAUTH_USERCACHE_TYPE', 1 );
 ```
 
-## Notes
+## Example: StartTLS on port 389
 
-- For `ldaps://`, set `LDAPAUTH_LDAP_URI` and `LDAPAUTH_START_TLS` to `false`.
-- For StartTLS on 389, leave `LDAPAUTH_LDAP_URI` unset and set `LDAPAUTH_START_TLS` to `true`.
-- The CA certificate must be in the system's trust store (e.g. `/etc/ssl/certs`, updated with `update-ca-certificates`, or `SSL_CERT_FILE` / `CURL_CA_BUNDLE` for libldap).
+```php
+define( 'LDAPAUTH_HOST', 'ad.example.com' );
+define( 'LDAPAUTH_PORT', 389 );
+define( 'LDAPAUTH_BASE', 'DC=example,DC=com' );
+define( 'LDAPAUTH_USERNAME_FIELD', 'sAMAccountName' );
+define( 'LDAPAUTH_SEARCH_USER', 'CN=ldap,DC=example,DC=com' );
+define( 'LDAPAUTH_SEARCH_PASS', 'your-secure-password' );
+define( 'LDAPAUTH_START_TLS', true );
+define( 'LDAPAUTH_ALL_USERS_ADMIN', true );
+define( 'LDAPAUTH_USERCACHE_TYPE', 1 );
+```
+
+## Troubleshooting
+
+- Check the PHP error log, usually at `/var/log/php.log`.
+- Check your web server logs.
+- You can enable `LDAPAUTH_DEBUG` to print more debug info.
+
+## About the user cache
+
+When a successful login is made against an LDAP server, the plugin will cache the username and encrypted password. Currently, this is done by saving them in an array in the YOURLS options table. This has some advantages:
+
+- It reduces requests to the LDAP server.
+- It means that users can still log in even if the LDAP server is unreachable.
+- It means that the YOURLS API can be used by LDAP users.
+
+Unfortunately, the cache will not scale well. This is because it integrates tightly with YOURLS's internal auth mechanism, and that does not scale. If you have a few tens of LDAP users likely to use your YOURLS installation, it should be fine. Much more than that, and you may see performance issues. If so, you should probably disable the cache. This will mean that your LDAP users will not be able to use the API. At least not unless they are also listed in `users/config.php`, which suffers from the same scaling problems.
 
 ## License
 
-This plugin is based on `mattv8/yourls-ldap-plugin`, which is licensed under the GNU General Public License v3. The original license and copyright remain with the original authors.
-
-
-
-yourls-ldap-plugin
-==================
-
-This plugin for [YOURLS](https://github.com/YOURLS/YOURLS) enables the simple use of [LDAP](http://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) for user authentication.
-
-Installation
-------------
-1. Download the latest yourls-ldap-plugin.
-2. Copy the plugin folder into your user/plugins folder for YOURLS.
-3. Set up the parameters for yourls-ldap-plugin in YOURLS configuration user/config.php (see below).
-4. Activate the plugin with the plugin manager in the admin interface.
-
-Usage
------
-When yourls-ldap-plugin is enabled and a user was not successfully authenticated using data specified in yourls_user_passwords, an LDAP authentication attempt will be made. If LDAP authentication is successful, then you will immediately go to the admin interface.
-
-You can also set a privileged account to search the LDAP directory with. This is useful for directories that don't allow anonymous binding. If you define a suitable template, the current user will be used for binding. This is useful for Active Directory / Samba.
-
-Setting the groups settings will check if the user is a member of that group before logging them in and storing their credentials. This check is only performed the first time they authenticate or when their password changes.
-
-yourls-ldap-plugin, by default, will now implement a simple cache of LDAP users. As well as reducing requests to the LDAP server, this has the effect of allowing the YOURLS API to work with LDAP users.
-
-Configuration
--------------
-
-  * define( 'LDAPAUTH_HOST', 'ldaps://ldap.domain.com' ); // LDAP host name, IP, or URL. You can use ldaps://host for LDAP with TLS
-  * define( 'LDAPAUTH_PORT', '636' ); // LDAP server port - often 389 or 636 for TLS (LDAPS)
-  * define( 'LDAPAUTH_BASE', 'dc=domain,dc=com' ); // Base DN (location of users)
-  * define( 'LDAPAUTH_USERNAME_FIELD', 'uid'); // (optional) LDAP field name in which the username is stored
-
-### To use a privileged account for the user search:
-  * define( 'LDAPAUTH_SEARCH_USER', 'cn=your-user,dc=domain,dc=com' ); // (optional) Privileged user to search with
-  * define( 'LDAPAUTH_SEARCH_PASS', 'the-pass'); // (optional) (only if LDAPAUTH_SEARCH_USER set) Privileged user pass
-
-### To define a template to bind using the current user for the search: Use %s as the placeholder for the current username
-  * define( 'LDAPAUTH_BIND_WITH_USER_TEMPLATE', '%s@myad.domain' ); // (optional) Use %s as the placeholder for the current username
-
-### To use a custom LDAP search filter:
-  * define( 'LDAPAUTH_SEARCH_FILTER', '(&(samaccountname=%s)(memberof=YOURLS-ADMINS,OU=Groups,DC=example,DC=com))' ); // Use %s as the placeholder for the current username
-
-If this option is not set, the filter is based only on LDAPAUTH_USERNAME_FIELD (default).
-This is useful if a more advanced filter is needed, like when using AD nested groups.
-For searching based on AD Nested group `LDAP_MATCHING_RULE_IN_CHAIN` OID (1.2.840.113556.1.4.1941) must be specified for the user's memberof attribute.
-Example of a filter based on AD nested group:
-`define( 'LDAPAUTH_SEARCH_FILTER', '(&(samaccountname=%s)(memberof:1.2.840.113556.1.4.1941:=YOURLS-ADMINS,OU=Groups,DC=example,DC=com))' );`
-
-### To check group membership before authenticating:
-
-There's two different approach to authorize the user to connect :
-  * Attribute based. Access is granted based on an attribute on the user entry (memberOf, OU, ect)
-  * Group based. LDAP Lookup is performed to check if the user is member of the defined list of groups
-
-**Attribute based** (default behaviour)
-
-  * define( 'LDAPAUTH_GROUP_MODE', 'attribute'); // default mode
-  * define( 'LDAPAUTH_GROUP_ATTR', 'memberof' ); // (optional) LDAP groups attribute
-  * define( 'LDAPAUTH_GROUP_REQ', 'the-group;another-admin-group'); // (only if LDAPAUTH_GROUP_REQ set) Group/s the user must be in. Allows multiple, semicolon-delimited
-
-**Group based**
-
-  * define( 'LDAPAUTH_GROUP_MODE', 'group'); // Authorization mode. lookup groups and check for user membership
-  * define( 'LDAPAUTH_GROUP_BASE', 'ou=groups,dc=example,dc=org' ); // Base DN for group lookups
-  * define( 'LDAPAUTH_GROUP_ATTR', 'cn' ); // group name attribute
-  * define( 'LDAPAUTH_GROUP_MEMBER', 'member' ); // membership attribute
-  * define( 'LDAPAUTH_GROUP_MEMBER_TYPE', 'dn' ); // group member reference. either 'dn' (default) or 'uid'
-  * define( 'LDAPAUTH_GROUP_REQ', 'yourlsadmin'); // Group/s user must be in. Allows multiple, semicolon delimited
-
-Note : Group based authorization **requires** LDAPAUTH_SEARCH_USER and LDAPAUTH_SEARCH_PASS. This requirement is checked when the plugin is loaded.
-
-### To define the scope of group req search:
-  * define( 'LDAPAUTH_GROUP_SCOP', 'sub' ); // if not defined the default is 'sub', and will check for the user in all the subtree. The other option is 'base', which will search only members of the exact req
-
-### To define the type of user cache used:
-  * define( 'LDAPAUTH_USERCACHE_TYPE', 0); // (optional) Defaults to 1, which caches users in the options table. 0 turns off caching. Other values are currently undefined but may be one day
-
-### To automatically add LDAP users to config.php:
-  * define( 'LDAPAUTH_ADD_NEW', true ); // (optional) Add LDAP users to config.php
-
-### To use Active Directory Sites and Services DNS entry for LDAP server name lookup
-  * define( 'LDAPAUTH_DNS_SITES_AND_SERVICES', '_ldap._tcp.corporate._sites.yourdomain.com' ); // If using Active Directory with multiple Domain Controllers, the safe way to use DNS to look up your active LDAP server names.  If set, it will be used to override the hostname portion of LDAPAUTH_HOST.
-  * define( 'LDAPAUTH_HOST', 'ldap://'); // LDAP protocol without the hostname. You can use 'ldaps://' for LDAP with TLS.
-
-### To prevent following LDAP referrals
-  * define( 'LDAPAUTH_LDAP_OPT_REFERRALS', 0 ); // (optional) Defaults to 1.  When using Active Directory, following LDAP referrals can fail.  It will fail in a way that causes the ldap_search function to hang for at least a minute.  Related [issue](https://github.com/MISP/MISP/issues/2749).
-
-NOTE: This will require config.php to be writable by your webserver user. This function is now largely unneeded because the database-based cache offers similar benefits without the need to make config.php writable. It is retained for backward compatibility.
-
-Troubleshooting
----------------
-  * Check the PHP error log usually at `/var/log/php.log`
-  * Check your web server logs
-  * You can try modifying the plugin code to print some more debug info
-
-About the user cache
---------------------
-When a successful login is made against an LDAP server, the plugin will cache the username and encrypted password. Currently, this is done by saving them in an array in the YOURLS options table. This has some advantages:
-
-  * It reduces requests to the LDAP server
-  * It means that users can still log in even if the LDAP server is unreachable
-  * It means that the YOURLS API can be used by LDAP users
-
-Unfortunately, the cache will not scale well. This is because it integrates tightly with YOURLS's internal auth mechanism, and that does not scale. If you have a few tens of LDAP users likely to use your YOURLS installation, it should be fine. Much more than that, and you may see performance issues. If so, you should probably disable the cache. This will mean that your LDAP users will not be able to use the API. At least not unless they are also listed in users/config.php, which suffers from the same scaling problems.
-
-License
--------
-Original Plugin Author(s):<br>
-Copyright 2013 K3A, #1davoaust<br>
+Original Plugin Author(s):  
+Copyright 2013 K3A, #1davoaust  
 Copyright 2013 Nicholas Waller (code@nicwaller.com) as I used some parts of his CAS authentication plugin :)
 
-Maintainer(s):<br>
-Matt Visnovsky #mattv8<br>
+Maintainer(s):  
+Matt Visnovsky #mattv8
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/plugin.php
+++ b/plugin.php
@@ -124,6 +124,9 @@ function ldapauth_get_ldap_connection()
 			die("Cannot connect to LDAP for site and service " . LDAPAUTH_DNS_SITES_AND_SERVICES);
 		}
 	} else {
+		if (defined("LDAPAUTH_LDAP_URI") && LDAPAUTH_LDAP_URI) {
+			return ldap_connect(LDAPAUTH_LDAP_URI);
+		}
 		return ldap_connect(LDAPAUTH_HOST, LDAPAUTH_PORT);
 	}
 }
@@ -180,6 +183,10 @@ function ldapauth_is_valid_user($value)
 		$ldapConnection = ldapauth_get_ldap_connection();
 		if (!$ldapConnection) die("Cannot connect to LDAP " . LDAPAUTH_HOST);
 		ldap_set_option($ldapConnection, LDAP_OPT_PROTOCOL_VERSION, 3);
+		ldap_set_option($ldapConnection, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_DEMAND);
+		if (defined("LDAPAUTH_START_TLS") && LDAPAUTH_START_TLS) {
+			@ldap_start_tls($ldapConnection);
+		}
 		//ldap_set_option($ldapConnection, LDAP_OPT_REFERRALS, 0);
 
 		// should we to try and bind using the credentials being logged in with?


### PR DESCRIPTION
Add LDAPAUTH_LDAP_URI constant for ldaps:// endpoints and use LDAP_OPT_X_TLS_DEMAND for StartTLS certificate verification. Backwards compatible: falls back to LDAPAUTH_HOST/LDAPAUTH_PORT if the URI is not defined.

This patch was prepared with assistance from an AI coding assistant; I have reviewed and tested it in my environment.